### PR TITLE
Fix syntax error.

### DIFF
--- a/ks.cfg
+++ b/ks.cfg
@@ -148,6 +148,7 @@ cat > /home/fedora/.fluxbox/usermenu <<EOF
 EOF
 chown -R fedora.fedora /home/fedora/.fluxbox
 init q
+%end
 
 # build piuio support
 %post --nochroot --log=/mnt/sysimage/root/ks-post-nochroot.log


### PR DESCRIPTION
Install would fail without the added %end line.
